### PR TITLE
Fix bug when last id has duplicates in the array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,14 +13,7 @@ export function _idBuilder(ids) {
                 reject(new Error('No valid Ids supplied to _idBuilder function, Ids supplied: ' + ids))
             }
 
-            let idUrl = "";
-            _.forEach(idArray, function (value) {
-                if (value === _.last(idArray)) {
-                    idUrl += value;
-                } else {
-                    idUrl += value + ',';
-                }
-            });
+            let idUrl = _.reduce(idArray, function(acc, curr) { return acc + "," + curr; });
             fulfill({
                 urlPart: idUrl,
                 array: idArray


### PR DESCRIPTION
If the last id had duplicates, they would be concatenated without the separating comma.  The API will de-dupe the response anyway, so it considers duplicate ids valid in the request. This is a bit cleaner too.
